### PR TITLE
Fixed tanh/sigmoid types

### DIFF
--- a/breze/arch/component/varprop/transfer.py
+++ b/breze/arch/component/varprop/transfer.py
@@ -163,7 +163,10 @@ def sigmoid(mean, var):
     var_ : Theano variable
         Theano variable of the shape ``r``.
     """
-    make_mean = lambda m, s2: T.nnet.sigmoid(m / (T.sqrt(1 + PI * s2 / 8)))
+    def make_mean(m, s2):
+        # If we do not cast, PI will be float64 in all cases.
+        pre_sig = m / (T.sqrt(1 + T.cast(PI, theano.config.floatX) * s2 / 8))
+        return T.nnet.sigmoid(pre_sig)
 
     a = 4 - 2 * SQRT_2
     b = -np.log(SQRT_2 - 1)


### PR DESCRIPTION
Issue: FastDropoutRnns with `theano.config.floatX='float32'` not working (at least to me, with default theano settings). That is because of the function applied in the "recurrent layer". More concretely, `tanh`, and `sigmoid` always returned `float64`. Casting `PI` to `floatX` solves the problem.

Curious, because PI is only assigned at the beginning with `PI = np.array(np.pi, dtype=theano.config.floatX)`, so it should be `floatX` already. Even more curiously, the debugger states that `PI.dtype` is `float64` whereas `np.array(np.pi, dtype=theano.config.floatX)` is `float32`. 
