### PR TITLE
Added random state feature

### DIFF
--- a/breze/arch/util.py
+++ b/breze/arch/util.py
@@ -392,6 +392,7 @@ class Model(object):
     """
 
     def __init__(self):
+        self.random_state = None
         self.updates = collections.defaultdict(dict)
         self._init_pars()
         self._init_exprs()

--- a/breze/learn/base.py
+++ b/breze/learn/base.py
@@ -209,13 +209,14 @@ class SupervisedBrezeWrapperBase(BrezeWrapperBase):
         else:
             if imp_weight is not None:
                 data = iter_minibatches([X, Z, imp_weight], self.batch_size,
-                                        list(self.sample_dim) + [self.sample_dim[0]])
+                                        list(self.sample_dim) + [self.sample_dim[0]],
+                                        random_state=self.random_state)
                 data = ((cast_array_to_local_type(x),
                          cast_array_to_local_type(z),
                          cast_array_to_local_type(w)) for x, z, w in data)
             else:
                 data = iter_minibatches([X, Z], self.batch_size,
-                                        self.sample_dim)
+                                        self.sample_dim, random_state=self.random_state)
 
                 data = ((cast_array_to_local_type(x),
                          cast_array_to_local_type(z)) for x, z in data)
@@ -392,7 +393,7 @@ class UnsupervisedBrezeWrapperBase(BrezeWrapperBase):
         elif batch_size < 1:
             raise ValueError('need strictly positive batch size')
         else:
-            data = iter_minibatches(item, self.batch_size, self.sample_dim)
+            data = iter_minibatches(item, self.batch_size, self.sample_dim, random_state=self.random_state)
         args = ((i, {}) for i in data)
         return args
 

--- a/breze/learn/mlp.py
+++ b/breze/learn/mlp.py
@@ -80,13 +80,17 @@ class Mlp(Model, SupervisedBrezeWrapperBase):
                  imp_weight=False,
                  optimizer='lbfgs',
                  batch_size=None,
-                 max_iter=1000, verbose=False):
+                 max_iter=1000, verbose=False,
+                 random_state=None):
         self.n_inpt = n_inpt
         self.n_hiddens = n_hiddens
         self.n_output = n_output
         self.hidden_transfers = hidden_transfers
         self.out_transfer = out_transfer
         self.loss = loss
+
+
+
 
         self.optimizer = optimizer
         self.batch_size = batch_size
@@ -98,6 +102,7 @@ class Mlp(Model, SupervisedBrezeWrapperBase):
         self.f_predict = None
 
         super(Mlp, self).__init__()
+        self.random_state = random_state
 
     def _init_pars(self):
         spec = mlp.parameters(self.n_inpt, self.n_hiddens, self.n_output)

--- a/tests/arch/test_random_state.py
+++ b/tests/arch/test_random_state.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+import climin.initialize
+from breze.learn.mlp import Mlp
+import numpy as np
+
+
+
+def produce_mlp_results(seed):
+    optimizer = ('rmsprop', {'decay': 0.9,
+    'momentum': 0.85,
+    'step_rate': 0.00005,
+    'step_rate_max': 0.05,
+    'step_rate_min': 1e-06})
+
+
+    size_inpt = 10
+    size_output = 1
+    max_iter = 20
+    examples = 15
+
+    random_state = np.random.RandomState(seed)
+    random_state_2 = np.random.RandomState(3)
+
+    model = Mlp(size_inpt, [10], size_output, ['rectifier'], 'sigmoid', 'squared',
+                optimizer=optimizer, batch_size=1, random_state=random_state)
+
+    climin.initialize.randomize_normal(model.parameters.data, 0, 1, random_state=random_state_2)
+    parameters_original = model.parameters.data.copy()
+
+    X = random_state_2.rand(examples*size_inpt).reshape(examples, size_inpt)
+    Z = np.ones((examples, size_output))
+
+    for info in model.iter_fit(X, Z):
+        if info['n_iter'] == max_iter:
+            break
+
+    parameters_final = model.parameters.data.copy()
+
+    return parameters_original, parameters_final
+
+
+def test_parameter_set_data_change():
+    #Try several times and with different seeds
+    for i in range(10):
+        parameters_original1, parameters_final1 = produce_mlp_results(i+1)
+        parameters_original2, parameters_final2 = produce_mlp_results(i+1)
+        parameters_original3, parameters_final3 = produce_mlp_results(i+2)
+        assert np.allclose(parameters_original1, parameters_original2)
+        assert not np.allclose(parameters_original1, parameters_final1)
+        assert np.allclose(parameters_final1, parameters_final2)
+        assert np.allclose(parameters_original2, parameters_original3)
+        assert not np.allclose(parameters_final2, parameters_final3)
+
+
+test_parameter_set_data_change()


### PR DESCRIPTION
This adds the functionality of getting the mini batches in the same order if the user provides a random state object. Depends on https://github.com/BRML/climin/pull/22
The only that is needed is that the `random_state` attribute of a model is initialized as what we want (which by default is `None` in all models). Done the example for `Mlp`.

Included some test cases for this for the `Mlp` model.
