### PR TITLE
Match the corrupt mask definition (and dropout mlp calls)

### DIFF
--- a/breze/arch/component/corrupt.py
+++ b/breze/arch/component/corrupt.py
@@ -85,5 +85,5 @@ def mask(arr, p, rng=None):
     """
     if rng is None:
         rng = T.shared_randomstreams.RandomStreams()
-    this_mask = T.cast(rng.binomial(size=arr.shape, p=p), theano.config.floatX)
+    this_mask = T.cast(rng.binomial(size=arr.shape, p=1-p), theano.config.floatX)
     return arr * this_mask


### PR DESCRIPTION
The probability of success is p, therefore the probability of being set to zero is 1-p. If this is not changed then its calls in the dropout part of mlp and the description of corrupt.mask should be changed.
