### PR TITLE
Distribution stability

### DIFF
--- a/breze/arch/construct/layer/distributions.py
+++ b/breze/arch/construct/layer/distributions.py
@@ -20,7 +20,7 @@ def recover_time(X, time_steps):
 
 def normal_logpdf(xs, means, vrs):
     energy = -(xs - means) ** 2 / (2 * vrs)
-    partition_func = -T.log(T.sqrt(2 * np.pi * vrs))
+    partition_func = - 0.5 * T.log(2 * np.pi * vrs)
     return partition_func + energy
 
 
@@ -67,12 +67,12 @@ class DiagGauss(Distribution):
             return sample
 
     def nll(self, X, inpt=None):
-        var_offset = 1e-4
+        var_offset = 0.0  # 1e-4
         var = self.var
         var += var_offset
         residuals = X - self.mean
         weighted_squares = -(residuals ** 2) / (2 * var)
-        normalization = T.log(T.sqrt(2 * np.pi * var))
+        normalization = 0.5 * T.log(2 * np.pi * var)
         ll = weighted_squares - normalization
         return -ll
 

--- a/breze/arch/construct/layer/distributions.py
+++ b/breze/arch/construct/layer/distributions.py
@@ -114,8 +114,8 @@ class Bernoulli(Distribution):
 
     def nll(self, X, inpt=None):
         rate = self.rate
-        rate *= 0.999
-        rate += 0.0005
+        # rate *= 0.999
+        # rate += 0.0005
         return -(X * T.log(rate) + (1 - X) * T.log(1 - rate))
 
 


### PR DESCRIPTION
- Removed correction terms in Bernoulli NLL (assuming the rate is obtained through a sigmoid output transfer, which is the case in all uses within breze), because they disable several theano optimizations: Firstly log(sigmoid(z)) = -softplus(-z) and log(1-sigmoid(z)) = - softplus(z). This is defined for all values of z, making the previous correction terms unnecessary, since their only purpose was to prevent log(0). Secondly the derivative of the nll simplifies greatly without these terms.
Further dropping these terms allows extreme rates outside the interval (0.0005, 0.9995), which come up in a lot of applications (e.g. in MNIST there are several pixels, which are exactly 0 in all images). This leads to better fitting models: In the case of a very simple VAE the best loss improved from 101.9 to 101.1.

- Simplified computation of the NLL of Gaussians and removed unnecessary stability term applied inside DiagGauss, since in all cases within breze the definition of the variance passed to DiagGauss already ensures > 0. This correction removes the bias present, when taking the NLL of distribution samples.