### PR TITLE
Error in the estimation of NLL in SGVB

### DIFF
--- a/breze/learn/sgvb/base.py
+++ b/breze/learn/sgvb/base.py
@@ -40,15 +40,7 @@ def estimate_nll(X, f_nll_z, f_nll_x_given_z, f_nll_z_given_x,
         log_recog[i] = ma.assert_numpy(-f_nll_z_given_x(Z, X))
 
     d = log_prior + log_posterior - log_recog
-
-    while d.ndim > 1:
-        d = d.sum(-1)
-    ll = logsumexp(d, 0) - np.log(n_samples)
-
-    # Normalize to average.
-    ll /= X.shape[0]
-    if X.ndim == 3:
-        ll /= X.shape[1]
+    ll = logsumexp(d, 0).mean() - np.log(n_samples)
     return -ll
 
 


### PR DESCRIPTION
Summation of the samples within the batch (i.e. different data samples, NOT samples drawn from the recognition model) is performed too early: Currently inside the logsumexp, but it should be outside, because one wants to calculate the average nll over the batch, so first one has to estimate the nll for each element in the batch (done in the logsumexp) and the compute the average of these. It can be shown, that the current breze version yields a strictly greater nll than the real estimate.